### PR TITLE
Use unquoted references to resources/attributes

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -31,7 +31,7 @@ resource "aws_lambda_function" "lambda_stream" {
   }
 
   lifecycle {
-    ignore_changes = ["filename", "last_modified"]
+    ignore_changes = [filename, last_modified]
   }
 }
 
@@ -50,5 +50,5 @@ resource "aws_cloudwatch_log_subscription_filter" "test_lambdafunction_logfilter
   destination_arn = aws_lambda_function.lambda_stream.arn
   distribution    = "ByLogStream"
 
-  depends_on = ["aws_lambda_permission.allow_cloudwatch"]
+  depends_on = [aws_lambda_permission.allow_cloudwatch]
 }


### PR DESCRIPTION
so as to fix deprecation warnings in 0.12.14 and above

```
Warning: Quoted references are deprecated

  on .terraform/modules/logdna/main.tf line 34, in resource "aws_lambda_function" "lambda_stream":
  34:     ignore_changes = ["filename", "last_modified"]

In this context, references are expected literally rather than in quotes.
Terraform 0.11 and earlier required quotes, but quoted references are now
deprecated and will be removed in a future version of Terraform. Remove the
quotes surrounding this reference to silence this warning.


Warning: Quoted references are deprecated

  on .terraform/modules/logdna/main.tf line 34, in resource "aws_lambda_function" "lambda_stream":
  34:     ignore_changes = ["filename", "last_modified"]

In this context, references are expected literally rather than in quotes.
Terraform 0.11 and earlier required quotes, but quoted references are now
deprecated and will be removed in a future version of Terraform. Remove the
quotes surrounding this reference to silence this warning.


Warning: Quoted references are deprecated

  on .terraform/modules/logdna/main.tf line 53, in resource "aws_cloudwatch_log_subscription_filter" "test_lambdafunction_logfilter":
  53:   depends_on = ["aws_lambda_permission.allow_cloudwatch"]

In this context, references are expected literally rather than in quotes.
Terraform 0.11 and earlier required quotes, but quoted references are now
deprecated and will be removed in a future version of Terraform. Remove the
quotes surrounding this reference to silence this warning.
```